### PR TITLE
fix: exit successfully when submitting a listed add-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This plugin requires some parameters to be set, so be sure to check below and fi
 
 ### `publish`
 
-Creates an unsigned XPI file out of the source directory and uploads it to the Mozilla Add On, using the web-ext sign command. The output from the sign command will be passed through to the console. If the package is validated and signed, it will downloaded the signed XPI file and store it in the artifacts directory under the specified file name.
+Creates an unsigned XPI file out of the source directory and uploads it to the Mozilla Add On, using the web-ext sign command. The output from the sign command will be passed through to the console. If the package is validated and signed, it will download the signed XPI file and store it in the artifacts directory under the specified file name. If the package is validated but not signed (including the case where manual review is required), it will store the unsigned XPI file in the artifacts directory.
 
 #### `publish` parameters
 

--- a/src/publish.js
+++ b/src/publish.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const path = require('path')
 
 const webExt = require('web-ext').default
+const defaultAddonSigner = require('sign-addon')
 
 const { verifyOptions } = require('./utils')
 
@@ -22,14 +23,29 @@ const publish = async options => {
     } = verifyOptions(options, ['extensionId', 'targetXpi'])
 
     const { FIREFOX_API_KEY, FIREFOX_SECRET_KEY } = process.env
-    const { success, downloadedFiles } = await webExt.cmd.sign({
-        apiKey: FIREFOX_API_KEY,
-        apiSecret: FIREFOX_SECRET_KEY,
-        artifactsDir,
-        channel,
-        id: extensionId,
-        sourceDir,
-    })
+
+    let unsignedXpiPath
+    const signAddon = async params => {
+        unsignedXpiPath = params.xpiPath
+        const result = await defaultAddonSigner(params)
+        if (!result.success && result.errorCode === 'ADDON_NOT_AUTO_SIGNED') {
+            result.success = true
+            result.downloadedFiles = result.downloadedFiles || []
+        }
+        return result
+    }
+
+    const { success, downloadedFiles } = await webExt.cmd.sign(
+        {
+            apiKey: FIREFOX_API_KEY,
+            apiSecret: FIREFOX_SECRET_KEY,
+            artifactsDir,
+            channel,
+            id: extensionId,
+            sourceDir,
+        },
+        { signAddon },
+    )
     if (!success) {
         throw new Error(
             'Signing the extension failed. See the console output from web-ext sign for the validation link',
@@ -37,7 +53,7 @@ const publish = async options => {
     }
     const [xpiFile] = downloadedFiles
     fs.renameSync(
-        path.join(artifactsDir, xpiFile),
+        xpiFile ? path.join(artifactsDir, xpiFile) : unsignedXpiPath,
         path.join(artifactsDir, targetXpi),
     )
 }


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->
- Fix #88 .
- When AMO requires manual review for a listed add-on, save the unsigned extension in the artifacts directory and exit successfully.

### Checklist

- [x] This PR has updated documentation
- [ ] This PR has sufficient testing

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->

### Comments
<!-- Any other comments you want to include for reviewers. -->
