### PR TITLE
fix: import 'sign-addon' correctly

### DIFF
--- a/src/publish.js
+++ b/src/publish.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 
 const webExt = require('web-ext').default
-const defaultAddonSigner = require('sign-addon')
+const defaultAddonSigner = require('sign-addon').default
 
 const { allowedChannels } = require('./constants')
 const { verifyOptions } = require('./utils')

--- a/tests/__mocks__/sign-addon.js
+++ b/tests/__mocks__/sign-addon.js
@@ -1,1 +1,3 @@
-module.exports = jest.fn()
+module.exports = {
+    default: jest.fn(),
+}

--- a/tests/publish.test.js
+++ b/tests/publish.test.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 
 const { vol } = require('memfs')
-const signAddon = require('sign-addon')
+const signAddon = require('sign-addon').default
 
 const { publish } = require('../src')
 


### PR DESCRIPTION
## Description
<!-- Add a bulleted list of items changed or added -->

### Checklist

- [ ] This PR has updated documentation
- [x] This PR has sufficient testing

## DevQA

### Comments
<!-- Any other comments you want to include for reviewers. -->
I unsuccessfully tried to release my add-on using v0.2.4 due to the following errors:
```
[10:43:23 AM] [semantic-release] › ℹ  Start step "publish" of plugin "semantic-release-firefox-add-on"
Building web extension from dist/firefox/production
[10:43:23 AM] [semantic-release] › ✖  Failed step "publish" of plugin "semantic-release-firefox-add-on"
[10:43:23 AM] [semantic-release] › ✖  An error occurred while running semantic-release: TypeError: defaultAddonSigner is not a function
    at signAddon (/home/runner/work/uBlacklist/uBlacklist/node_modules/semantic-release-firefox-add-on/src/publish.js:34:30)
    at /home/runner/work/uBlacklist/uBlacklist/node_modules/web-ext/dist/web-ext.js:1:66145
    at publish (/home/runner/work/uBlacklist/uBlacklist/node_modules/semantic-release-firefox-add-on/src/publish.js:46:33)
    at validator (/home/runner/work/uBlacklist/uBlacklist/node_modules/semantic-release/lib/plugins/normalize.js:34:24)
    at /home/runner/work/uBlacklist/uBlacklist/node_modules/semantic-release/lib/plugins/pipeline.js:37:34
    at async Promise.all (index 0)
    at next (/home/runner/work/uBlacklist/uBlacklist/node_modules/p-reduce/index.js:16:18) {
  pluginName: 'semantic-release-firefox-add-on'
}
TypeError: defaultAddonSigner is not a function
    at signAddon (/home/runner/work/uBlacklist/uBlacklist/node_modules/semantic-release-firefox-add-on/src/publish.js:34:30)
    at /home/runner/work/uBlacklist/uBlacklist/node_modules/web-ext/dist/web-ext.js:1:66145
    at publish (/home/runner/work/uBlacklist/uBlacklist/node_modules/semantic-release-firefox-add-on/src/publish.js:46:33)
    at validator (/home/runner/work/uBlacklist/uBlacklist/node_modules/semantic-release/lib/plugins/normalize.js:34:24)
    at /home/runner/work/uBlacklist/uBlacklist/node_modules/semantic-release/lib/plugins/pipeline.js:37:34
    at async Promise.all (index 0)
    at next (/home/runner/work/uBlacklist/uBlacklist/node_modules/p-reduce/index.js:16:18) {
  pluginName: 'semantic-release-firefox-add-on'
}
##[error]Process completed with exit code 1.
```
`sign-addon` should be imported as `const defaultAddonSigner = require('sign-addon').default`.