### PR TITLE
ci: fix token, branch gating

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test, build, e2e]
     env:
-      NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - name: Install Node

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,7 +131,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [lint, test, build, e2e]
-    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
       - name: Install Node

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,6 +131,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [lint, test, build, e2e]
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - name: Install Node

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     ]
   },
   "release": {
-    "branches": ["master"],
     "dryRun": false,
     "plugins": [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
## Description

This undoes some of the eager gating on the release step to allow the `semantic-release` behaviour to kick in. Worth noting that this relies on default `semantic-release` behaviour which will make non-master (+ other namefilter) branches dry-runs.

This also feeds the org-level NPM token to the release step via an envvar that `semantic-release` expects.

### Checklist

- [ ] This PR has updated documentation
- [ ] This PR has sufficient testing

## DevQA

### DevQA Prep
<!-- Delete items that do not apply. -->
- Please `yarn install`, this PR uses a new package

### DevQA Steps
<!-- Fill in steps to DevQA this PR here -->

### Comments
<!-- Any other comments you want to include for reviewers. -->
