### PR TITLE
fix: let extension ID be configured in manifest.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ For more information on the source of these values, see [Mozilla Add On authenti
 
 #### `verifyConditions` parameters
 
-- `extensionId`: **REQUIRED** The extension id of the extension from the Mozilla Add On store. If this is not specified then a new extension will be created each time the release is run. In order to avoid issues arising due to this, the extension must be created in the Add On store first and the extension Id put into the semantic release configuration.
 
 - `targetXpi`: **REQUIRED** The filename of the XPI file to store in the artifacts directory.
+
+- `extensionId`: The extension id of the extension from the Mozilla Add On store. Must either be set in `manifest.json` or provided here. If this is not specified then a new extension will be created each time the release is run. In order to avoid issues arising due to this, the extension must be created in the Add On store first and the extension Id put into the semantic release configuration.
 
 - `sourceDir`: The path of the source directory. Defaults to `dist`.
 
@@ -77,9 +78,10 @@ Creates an unsigned XPI file out of the source directory and uploads it to the M
 
 #### `publish` parameters
 
-- `extensionId`: **REQUIRED** The extension id of the extension from the Mozilla Add On store.
 
 - `targetXpi`: **REQUIRED** The filename of the XPI file to store in the artifacts directory.
+
+- `extensionId`: The extension id of the extension from the Mozilla Add On store.
 
 - `sourceDir`: The path of the source directory. Defaults to `dist`.
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,8 +11,6 @@ const defaultOptions = {
 }
 
 const requiredOptions = {
-    extensionId:
-        'Omitting this would create a new extension instead of a new version.',
     targetXpi:
         'Omitting this would leave the xpi file unnamed when it is returned from mozilla.',
 }

--- a/src/publish.js
+++ b/src/publish.js
@@ -35,17 +35,19 @@ const publish = async (options) => {
         return result
     }
 
-    const { downloadedFiles } = await webExt.cmd.sign(
-        {
-            apiKey: FIREFOX_API_KEY,
-            apiSecret: FIREFOX_SECRET_KEY,
-            artifactsDir,
-            channel,
-            id: extensionId,
-            sourceDir,
-        },
-        { signAddon },
-    )
+    const signArgs = {
+        apiKey: FIREFOX_API_KEY,
+        apiSecret: FIREFOX_SECRET_KEY,
+        artifactsDir,
+        channel,
+        sourceDir,
+    }
+
+    if (extensionId) {
+        signArgs.id = extensionId
+    }
+
+    const { downloadedFiles } = await webExt.cmd.sign(signArgs, { signAddon })
     const [xpiFile] = downloadedFiles
     fs.renameSync(xpiFile, path.join(artifactsDir, targetXpi))
 }

--- a/src/verifyConditions.js
+++ b/src/verifyConditions.js
@@ -7,13 +7,35 @@ const { maybeThrowErrors, verifyOptions } = require('./utils')
 const verifyConditions = (options) => {
     const { verified, errors } = verifyOptions(options, requiredOptions, false)
     errors.push(...verifyOptions(process.env, requiredEnvs, false).errors)
-    const { manifestPath, sourceDir } = verified
-    const manifestExists = fs.existsSync(path.join(sourceDir, manifestPath))
+    const { extensionId, manifestPath, sourceDir } = verified
+    const joinedManifestPath = path.join(sourceDir, manifestPath)
+    const manifestExists = fs.existsSync(joinedManifestPath)
     if (!manifestExists) {
         errors.push(
             `${manifestPath} was not found in ${sourceDir}, path does not exist.`,
         )
+    } else {
+        const manifest = fs.readFileSync(joinedManifestPath, 'utf-8')
+        const manifestJson = JSON.parse(manifest)
+        const hasManifestId =
+            manifestJson &&
+            manifestJson.browser_specific_settings &&
+            manifestJson.browser_specific_settings.gecko &&
+            manifestJson.browser_specific_settings.gecko.id
+
+        if (!extensionId && !hasManifestId) {
+            errors.push(
+                'extension ID must be set in manifest.json or as extensionId config',
+            )
+        }
+
+        if (extensionId && hasManifestId) {
+            errors.push(
+                'extension ID can only be set by either manifest.json or extensionId config',
+            )
+        }
     }
+
     maybeThrowErrors(errors)
 }
 

--- a/tests/publish.test.js
+++ b/tests/publish.test.js
@@ -48,12 +48,6 @@ describe('publish', () => {
         jest.restoreAllMocks()
     })
 
-    it('fails if extensionId is not given', () => {
-        return expect(publish(mockOptions)).rejects.toThrow(
-            'extensionId is missing',
-        )
-    })
-
     it('fails if targetXpi is not given', () => {
         return expect(publish(mockOptions)).rejects.toThrow(
             'targetXpi is missing',


### PR DESCRIPTION
## Description

- Makes `extensionId` optional.
- Validates that ID is set either in `manifest.json` or in configuration for Semantic Release.

Fixes #418 

### Checklist

- [x] This PR has updated documentation
- [x] This PR has sufficient testing

## DevQA

### DevQA Prep

- None

### DevQA Steps

- Regression test existing setup with `extensionId`.
- Consider testing by setting the ID in `manifest.json` like in [verifyConditions.test.js](https://github.com/tophat/semantic-release-firefox-add-on/compare/master...wkillerud:semantic-release-firefox-add-on:ext-id?expand=1#diff-c128fd644b7e02ae925b974bdc758109d6b6b8d4ba0324371ee4f8fd9a02b6bb).